### PR TITLE
feat: add percentage metrics to statistics

### DIFF
--- a/docstr_health/checkers/docstring.py
+++ b/docstr_health/checkers/docstring.py
@@ -28,11 +28,14 @@ class DocstringChecker(BaseChecker):
     def get_statistics(self) -> list[Text]:
         statistics = []
         statistics.append(Text("Statistics:", justify="center"))
+        total = self.total_inspected_statuses
+
         for status, value in self.inspected_statuses.items():
             if value > 0:
                 symbol = config.parameters[f"{status}_symbol"]
                 color = config.parameters[f"{status}_color"]
-                statistics.append(Text(f"{symbol} {status} - {value}", style=color))
+                rate = round(value / total * 100, 1)
+                statistics.append(Text(f"{symbol} {status} - {value} ({rate}%)", style=color))
         return statistics
         # self.output.display_panel(
         #         text=inspected_functions,

--- a/docstr_health/cli/cli.py
+++ b/docstr_health/cli/cli.py
@@ -107,6 +107,11 @@ class RichOutput:
         end_section = False
 
         total_rows = len(table_data)
+        total = 0
+        if 'total' in data:
+            total = data['total']
+        else: 
+            total = sum([cnt for _, cnt in data.items()])
 
         for i, (status, count) in enumerate(table_data):
             # last line check
@@ -120,5 +125,6 @@ class RichOutput:
                 style=style,
                 justify="left",
             )
-            table.add_row(status_text, str(count), end_section=end_section)
+            percentage = round(int(count) / total * 100, 1)
+            table.add_row(status_text, str(count), f'{percentage}%', end_section=end_section)
         return table

--- a/docstr_health/main.py
+++ b/docstr_health/main.py
@@ -70,7 +70,7 @@ def main():
     tables_to_display.append(
         renderer.get_table(
             title="General statistics",
-            headers=["Metric", "Value"],
+            headers=["Metric", "Value", "Rate"],
             data=general_stat_data,
             sorting_reference=config.get_sorted_general_stat(),
             last_line_separator=True,
@@ -79,7 +79,7 @@ def main():
     tables_to_display.append(
         renderer.get_table(
             title="Number of modules each status",
-            headers=["Module status", "Quantity"],
+            headers=["Module status", "Quantity", "Rate"],
             data=statuses,
             sorting_reference=config.get_sorted_statuses(),
         )
@@ -90,7 +90,7 @@ def main():
         tables_to_display.append(
             renderer.get_table(
                 title="Skipped modules",
-                headers=["Module", "Error"],
+                headers=["Module", "Error", "Rate"],
                 data=skipped,
             )
         )


### PR DESCRIPTION
Add metric rates in:
- file statistics 
```
│  ────────────────────────────  │
│          Statistics:           │
│  ✗ bad - 20 (90.9%)            │
│  ✔ good - 2 (9.1%)             │
│                                │
```
- overall statistics
```
     General statistics          Number of modules each status    
┏━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┓ ┏━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃  Metric  ┃ Value ┃  Rate  ┃ ┃ Module status ┃ Quantity ┃ Rate  ┃
┡━━━━━━━━━━╇━━━━━━━╇━━━━━━━━┩ ┡━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━┩
│ class    │  21   │ 23.9%  │ │ ✗ bad         │    17    │ 81.0% │
│ function │  67   │ 76.1%  │ │ ⚠ warning     │    3     │ 14.3% │
├──────────┼───────┼────────┤ │ ✔ good        │    1     │ 4.8%  │
│ total    │  88   │ 100.0% │ └───────────────┴──────────┴───────┘
└──────────┴───────┴────────┘       
```

Closes #1 