### PR TITLE
feat: support pyproject.toml config (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .ruff_cache/
 .mypy_cache/
+.pytest_cache/
 venv/
 .venv/
 .venv-3.11/
@@ -11,6 +12,7 @@ venv/
 EXAMPLE.md
 .vscode
 *.log
+*.prof
 benchmarks/
 sampling/
 *.tape
@@ -21,3 +23,4 @@ dist/
 build/
 .env
 .python-version
+.coverage

--- a/docstr_health/core/config.py
+++ b/docstr_health/core/config.py
@@ -1,17 +1,23 @@
 import tomllib
 from importlib import metadata
 from pathlib import Path
+from typing import Any, Final
 
-_PACKAGE_ROOT: Path = Path(__file__).resolve().parent.parent
+_PACKAGE_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 _BASE_CACHE_DIR = Path.home() / ".cache" / "docstr-health"
 _REPOS_DIR = _BASE_CACHE_DIR / "repos"
 _LOGS_DIR = _BASE_CACHE_DIR / "logs"
+_PYPROJECT_FILE = _PACKAGE_ROOT.parent / "pyproject.toml"
 
 
 class Config:
     def __init__(self) -> None:
-        self.excluded = self.parameters.get("excluded", [])
+        self.pyproject_data = self._pyproject_data()
+        self.data = self._data()
+        self.parameters = self._parameters()
+        self.requires = self._requires()
+        self.excluded = self._excluded()
         self._cache_dir = _REPOS_DIR
 
     def get_cache_dir(self) -> Path:
@@ -25,18 +31,28 @@ class Config:
         return _LOGS_DIR
 
     @staticmethod
+    def _get_pyproject_file() -> Path:
+        return _PYPROJECT_FILE
+
+    def _pyproject_data(self) -> dict[str, Any]:
+        pyproject_path = self._get_pyproject_file()
+        if pyproject_path.exists():
+            with open(pyproject_path, "rb") as f:
+                data = tomllib.load(f)
+            return data
+        else:
+            return {}
+
+    @staticmethod
     def get_sorted_statuses() -> list[str]:
         return ["bad", "warning", "good", "special", "epic"]
 
-    @staticmethod
-    def get_version() -> str:
+    def get_version(self) -> str:
         try:
             return metadata.version("docstr-health")
         except metadata.PackageNotFoundError:
-            pyproject_path = _PACKAGE_ROOT.parent / "pyproject.toml"
-            if pyproject_path.exists():
-                with open(pyproject_path, "rb") as f:
-                    data = tomllib.load(f)
+            data = self.pyproject_data
+            if data:
                 return data.get("project", {}).get("version", "unknown")
             return "unknown"
 
@@ -50,20 +66,30 @@ class Config:
             "total",
         ]
 
-    @property
-    def data(self) -> dict:
+    def _data(self) -> dict[str, Any]:
         """The main interface for obtaining data from the configuration."""
         config_path = _PACKAGE_ROOT / "config.toml"
-        with open(config_path, "rb") as f:
-            return tomllib.load(f)
 
-    @property
-    def requires(self) -> dict:
+        data = {}
+
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+
+        pyproject_data = self.pyproject_data.get("tool", {}).get("docstr-health", {})
+
+        if pyproject_data:
+            data.setdefault("user_parameters", {}).update(pyproject_data)
+
+        return data
+
+    def _requires(self) -> dict[str, Any]:
         return self.data.get("requires_v4", {})
 
-    @property
-    def parameters(self) -> dict:
+    def _parameters(self) -> dict[str, Any]:
         return self.data.get("user_parameters", {})
+
+    def _excluded(self) -> list[str]:
+        return self.parameters.get("excluded", [])
 
     def ensure_directories(self) -> None:
         self.get_cache_dir().mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,6 @@ source-exclude = [
     "venv/",
     ".venv/",
 ]
+
+[tool.docstr-health]
+debug = false


### PR DESCRIPTION
Added support pyproject.toml config. By default, the config is read from config.toml, but if parameters are overwritten in the [tool.docstr-health] section of the projecttoml, they are read from there instead.

A performance bug was also fixed, where the file was read from disk every time the parameters were accessed.

Closes #8